### PR TITLE
Add support for V2 POST endpoint tweets

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -37,6 +37,7 @@ var JSONPAYLOAD_PATHS = [
   'direct_messages/events/new',
   'direct_messages/welcome_messages/new',
   'direct_messages/welcome_messages/rules/new',
+  'tweets'
 ];
 
 //


### PR DESCRIPTION
Adds support for the new V2 endpoints `tweets`, which needs the payload to have the Content-Type `application/json` .